### PR TITLE
index: Make DestinationType configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,16 +29,21 @@ Emitter(Camera.prototype);
 /**
  * Capture a picture and return a base64 string
  *
+ * @param {Number} [type]
  * @param {Function} fn
  * @return {Camera}
  * @api public
  */
 
-Camera.prototype.capture = function(fn) {
+Camera.prototype.capture = function(type, fn) {
   var self = this;
+  if ('function' == typeof type) {
+    fn = type;
+    type = 0; // DestinationType.DATA_URL
+  }
 
   this.camera.getPicture(success, error, {
-    destinationType: 0, // DestinationType.DATA_URL
+    destinationType: type,
     sourceType: 1 // PictureSourceType.CAMERA
   });
 
@@ -62,16 +67,22 @@ Camera.prototype.capture = function(fn) {
  *
  * TODO: blob support
  *
+ * @param {Number} [type]
  * @param {Function} fn
  * @return {Camera}
  * @api public
  */
 
-Camera.prototype.select = function(fn) {
+Camera.prototype.select = function(type, fn) {
   var self = this;
 
+  if ('function' == typeof type) {
+    fn = type;
+    type = 0; // DestinationType.DATA_URL
+  }
+
   this.camera.getPicture(success, error, {
-    destinationType: 0, // DestinationType.DATA_URL
+    destinationType: type, 
     sourceType: 0 // PictureSourceType.PHOTOLIBRARY
   });
 

--- a/test/camera.js
+++ b/test/camera.js
@@ -43,7 +43,7 @@ describe('Camera', function () {
 
   });
 
-  describe('capture', function () {
+  describe('#capture([type], fn)', function () {
 
     it('should turn a datauri into a blob', function () {
       navigator.camera.getPicture = function(success, error, options) {
@@ -71,9 +71,23 @@ describe('Camera', function () {
       })
     });
 
+    describe('given type', function(){
+      it('should use the type', function(done){
+        // NATIVE_URI = 2
+        navigator.camera.getPicture = function(success, _, opts){
+          assert(2 == opts.destinationType);
+          return success();
+        };
+
+        camera.capture(2, function(){
+          done();
+        });
+      });
+    });
+
   });
 
-  describe('select', function () {
+  describe('#select([type], fn)', function () {
 
     it('should turn selected image into blob', function() {
       navigator.camera.getPicture = function(success, error, options) {
@@ -99,6 +113,20 @@ describe('Camera', function () {
         assert(err);
         assert(!blob);
       })
+    });
+
+    describe('given type', function(){
+      it('should use the type', function(done){
+        // NATIVE_URI = 2
+        navigator.camera.getPicture = function(success, _, opts){
+          assert(2 == opts.destinationType);
+          return success();
+        };
+
+        camera.select(2, function(){
+          done();
+        });
+      });
     });
   });
 


### PR DESCRIPTION
The methods `Camera#select` and `Camera#capture` will now take an
optional `type` parameter, which allows you to specify the
`DestinationType` of the returned photo.
